### PR TITLE
global_vars: do not use getGlobalContext()

### DIFF
--- a/passes/global_vars.cc
+++ b/passes/global_vars.cc
@@ -132,7 +132,7 @@ bool GlobalVarsPass::runOnModule(Module &M) {
 	CallInst::Create(/*called*/initGVF, /*ret*/"", /*before*/mainF->begin()->getFirstNonPHI());
 
 	// beginning of function
-	BasicBlock* blockGVF = BasicBlock::Create(getGlobalContext(), "entry", initGVF);
+	BasicBlock* blockGVF = BasicBlock::Create(M.getContext(), "entry", initGVF);
 	IRBuilder<> builder(blockGVF);
 	
 	// insert store instructions and zero-initializer


### PR DESCRIPTION
This function was removed in newer versions of LLVM.

Port to newer versions of LLVM (tested on LLVM 7).