### PR TITLE
Add nestedgep pass

### DIFF
--- a/passes/CMakeLists.txt
+++ b/passes/CMakeLists.txt
@@ -33,7 +33,7 @@ message(STATUS "Cmake libpath ${CMAKE_LIBRARY_PATH}")
 
 # all LLVM passes
 #add_library (passes SHARED global_vars.cc lower_mem.cc lower_select.cc elim_phi.cc elim_const_expr.cc)
-add_library (passes SHARED global_vars.cc elim_const_expr.cc)
+add_library (passes SHARED global_vars.cc elim_const_expr.cc nestedgep.cc)
 set_target_properties(passes PROPERTIES LINK_FLAGS -Wl)
 
 # set the full path of libsl.so/.dylib

--- a/passes/nestedgep.cc
+++ b/passes/nestedgep.cc
@@ -1,0 +1,122 @@
+#include "nestedgep.hh"
+
+#include <llvm/IR/LegacyPassManager.h>
+#include <llvm/Transforms/IPO/PassManagerBuilder.h>
+
+#include <vector>
+
+using namespace llvm;
+
+bool NestedGepPass::runOnFunction(Function &F) {
+    mod = F.getParent();
+    for (auto &bb : F) {
+        for (auto &ins : bb) {
+            if (auto *gep = dyn_cast_or_null<GetElementPtrInst>(&ins)) {
+                processOperandList(gep->indices());
+            }
+        }
+    }
+
+    return true;
+}
+
+Value *NestedGepPass::processOperand(Value *value) {
+    auto *cex = dyn_cast_or_null<ConstantExpr>(value);
+    if (cex) {
+        return tryReplace(cex);
+    }
+
+    return nullptr;
+}
+
+void NestedGepPass::processOperandList(User::op_range ops) {
+    for (auto &use : ops) {
+        auto *replacement = processOperand(use.get());
+        if (replacement) use.set(replacement);
+    }
+}
+
+Value *NestedGepPass::tryReplaceSub(BinaryOperator *sub) {
+    processOperandList(sub->operands());
+
+    auto *op1 = dyn_cast_or_null<ConstantInt>(sub->getOperand(0));
+    auto *op2 = dyn_cast_or_null<ConstantInt>(sub->getOperand(1));
+
+    if (!op1 || !op2) {
+        return nullptr;
+    }
+
+    if (sub->hasNoSignedWrap()) {
+        int64_t a = op1->getSExtValue();
+        int64_t b = op2->getSExtValue();
+
+        return ConstantInt::getSigned(sub->getType(), a - b);
+
+    } else {
+        int64_t a = op1->getZExtValue();
+        int64_t b = op2->getZExtValue();
+
+        return ConstantInt::get(sub->getType(), a - b);
+    }
+}
+
+Value *NestedGepPass::tryReplaceZExt(CastInst *ci) {
+    processOperandList(ci->operands());
+    auto *op = cast<ConstantInt>(ci->getOperand(0));
+
+    return ConstantInt::get(ci->getDestTy(), op->getZExtValue());
+}
+
+Value *NestedGepPass::tryReplaceSExt(CastInst *ci) {
+    processOperandList(ci->operands());
+    auto *op = cast<ConstantInt>(ci->getOperand(0));
+
+    return ConstantInt::getSigned(ci->getDestTy(), op->getSExtValue());
+}
+
+Value *NestedGepPass::tryReplacePtrToInt(PtrToIntInst *pti) {
+    if (!pti) return nullptr;
+
+    auto *pto = pti->getPointerOperand();
+    if (auto *ce = dyn_cast_or_null<ConstantExpr>(pto)) {
+        auto *inst = ce->getAsInstruction();
+
+        if (auto *gep = dyn_cast_or_null<GetElementPtrInst>(inst)) {
+            auto &dl = mod->getDataLayout();
+            auto *ptrType = gep->getPointerOperand()->getType();
+
+            auto offset =
+                APInt::getNullValue(dl.getTypeAllocSizeInBits(ptrType));
+            if (gep->accumulateConstantOffset(dl, offset)) {
+                return ConstantInt::get(pti->getType(), offset);
+            }  // else the gep doesn't have constant offset and cannot be
+               // replaced
+        }      // else there is not gep as an operand. no idea what to do
+    }
+
+    return nullptr;
+}
+
+Value *NestedGepPass::tryReplace(ConstantExpr *ce) {
+    if (!ce) return nullptr;
+
+    auto *ins = ce->getAsInstruction();
+
+    switch (ins->getOpcode()) {
+        case Instruction::Sub:
+            return tryReplaceSub(cast<BinaryOperator>(ins));
+        case Instruction::ZExt:
+            return tryReplaceZExt(cast<CastInst>(ins));
+        case Instruction::SExt:
+            return tryReplaceSExt(cast<CastInst>(ins));
+        case Instruction::PtrToInt:
+            return tryReplacePtrToInt(cast<PtrToIntInst>(ins));
+        default:
+            return nullptr;
+    }
+}
+
+char NestedGepPass::ID = 0;
+static RegisterPass<NestedGepPass> X("nestedgep", "Evaluate inner GetElementPtr",
+                                    false /* Only looks at CFG */,
+                                    false /* Analysis Pass */);

--- a/passes/nestedgep.hh
+++ b/passes/nestedgep.hh
@@ -1,0 +1,29 @@
+#ifndef H_CONSTGEP_H
+#define H_CONSTGEP_H
+
+#include "llvm/IR/Module.h"
+#include "llvm/IR/Function.h"
+#include "llvm/IR/Instruction.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/Pass.h"
+
+class NestedGepPass : public llvm::FunctionPass {
+
+    public:
+        static char ID;
+        NestedGepPass() : llvm::FunctionPass(ID) {}
+        bool runOnFunction(llvm::Function& f) override;
+
+    private:
+        llvm::Module *mod;
+
+        llvm::Value *processOperand(llvm::Value *value);
+        void processOperandList(llvm::User::op_range ops);
+        llvm::Value *tryReplaceSub(llvm::BinaryOperator *sub);
+        llvm::Value *tryReplaceZExt(llvm::CastInst *ci);
+        llvm::Value *tryReplaceSExt(llvm::CastInst *ci);
+        llvm::Value *tryReplacePtrToInt(llvm::PtrToIntInst *pti);
+        llvm::Value *tryReplace(llvm::ConstantExpr *ce);
+};
+
+#endif


### PR DESCRIPTION
This pass computes value of inner GetElementPtr instructions. It is useful for C programs that compute offset of a field using something like `((struct S*) 0)->field` (for example [memleaks_test23_3.i#L706](https://github.com/sosy-lab/sv-benchmarks/blob/master/c/ldv-memsafety/memleaks_test23_3.i#L706)). After compiling C program with clang, this involves a GEP that uses PtrToInt, Sub, ZExt, SExt and another GEP inside of a ConstantExpr. That's why other instructions are handled by `tryReplace` too.