### PR TITLE
cmake: Fix compilation with GCC

### DIFF
--- a/passes/CMakeLists.txt
+++ b/passes/CMakeLists.txt
@@ -34,7 +34,6 @@ message(STATUS "Cmake libpath ${CMAKE_LIBRARY_PATH}")
 # all LLVM passes
 #add_library (passes SHARED global_vars.cc lower_mem.cc lower_select.cc elim_phi.cc elim_const_expr.cc)
 add_library (passes SHARED global_vars.cc elim_const_expr.cc nestedgep.cc)
-set_target_properties(passes PROPERTIES LINK_FLAGS -Wl)
 
 # set the full path of libsl.so/.dylib
 set(LIBPASSES_PATH ${PROJECT_BINARY_DIR}/libpasses${CMAKE_SHARED_LIBRARY_SUFFIX})


### PR DESCRIPTION
GCC (unlike Clang) does not like an empty list of options for linker.

Fixes:
[100%] Linking CXX shared library libpasses.so
c++: error: unrecognized command line option ‘-Wl’; did you mean ‘-W’?