### PR TITLE
passes/nestedgep: Fix compilation with LLVM 4-5

### DIFF
--- a/passes/nestedgep.cc
+++ b/passes/nestedgep.cc
@@ -1,5 +1,6 @@
 #include "nestedgep.hh"
 
+#include <llvm/ADT/iterator_range.h>
 #include <llvm/IR/LegacyPassManager.h>
 #include <llvm/Transforms/IPO/PassManagerBuilder.h>
 
@@ -12,7 +13,10 @@ bool NestedGepPass::runOnFunction(Function &F) {
     for (auto &bb : F) {
         for (auto &ins : bb) {
             if (auto *gep = dyn_cast_or_null<GetElementPtrInst>(&ins)) {
-                processOperandList(gep->indices());
+                // LLVM 4 and lower do not provide GetElementPtrInst::indices
+                // which is, however, nothing else than an inline call to
+                // llvm::make_range.
+                processOperandList(make_range(gep->idx_begin(), gep->idx_end()));
             }
         }
     }

--- a/passes/nestedgep.hh
+++ b/passes/nestedgep.hh
@@ -1,6 +1,7 @@
 #ifndef H_CONSTGEP_H
 #define H_CONSTGEP_H
 
+#include "llvm/IR/Constants.h"
 #include "llvm/IR/Module.h"
 #include "llvm/IR/Function.h"
 #include "llvm/IR/Instruction.h"


### PR DESCRIPTION
Untested, but It should work with older releases too.

Fixes:
```
/prostata/passes/nestedgep.cc: In member function 'virtual bool NestedGepPass::runOnFunction(llvm::Function&)':
/prostata/passes/nestedgep.cc:15:41: error: 'class llvm::GetElementPtrInst' has nomember named 'indices'; did you mean 'hasIndices'?
                 processOperandList(gep->indices());
                                         ^~~~~~~
                                         hasIndices
...
/prostata/passes/nestedgep.cc:51:24: error: invalid use of incomplete type 'class llvm::ConstantInt'
         int64_t a = op1->getSExtValue();
                        ^~
In file included from /prostata/passes/nestedgep.hh:7:0,
                 from /prostata/passes/nestedgep.cc:1:
/usr/include/llvm/IR/Instructions.h:46:7: note: forward declaration of 'class llvm::ConstantInt'
 class ConstantInt;
       ^~~~~~~~~~~
...
```