### PR TITLE
Makefile: do not build in debug mode by default

### DIFF
--- a/passes/Makefile
+++ b/passes/Makefile
@@ -1,7 +1,6 @@
 
 CMAKE = cmake
-CXXFLAGS += -std=c++11 -pedantic -Wall -fPIC -fno-rtti
-CXXFLAGS += -O0 -g -DDEBUG
+CXXFLAGS += -std=c++11 -pedantic -Wall -fPIC -fno-rtti -g
 # why is problem with RTTI in clang-3.8? clang-3.4 is OK...
 
 #LLVM_DIRECTORY = /home/nika/Desktop/programs/llvm-3.8
@@ -19,6 +18,9 @@ all:
 	cd ../passes_build && $(CMAKE) ../passes
 	$(MAKE) -C ../passes_build
 	cd ../tests && ./test.sh
+
+debug: CXXFLAGS += -O0 -DDEBUG
+debug: all
 
 # or not
 local: $(LIBS)


### PR DESCRIPTION
This fixes the following failure in Predator macOS CI (https://github.com/kdudka/predator/pull/81):

```
Error opening '/Users/runner/work/predator/predator/sl/../passes-src/passes_build/libpasses.dylib': dlopen(/Users/runner/work/predator/predator/sl/../passes-src/passes_build/libpasses.dylib, 0x0009): symbol not found in flat namespace (__ZNK4llvm5Value4dumpEv)
  -load request ignored.
opt: Unknown command line argument '-global-vars'.  Try: '/usr/local/Cellar/llvm@14/14.0.6/bin/opt --help'
opt: Did you mean '--globals-aa'?
opt: Unknown command line argument '-nestedgep'.  Try: '/usr/local/Cellar/llvm@14/14.0.6/bin/opt --help'
opt: Did you mean '--memdep'?
```