### PR TITLE
cmake: raise minimum required version to 3.5

### DIFF
--- a/passes/CMakeLists.txt
+++ b/passes/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.0)
+cmake_minimum_required (VERSION 3.5)
 
 # FIXME: Unfortunately, C is (at least temporarily) required due to a bug
 # in LLVM 14.  See https://github.com/llvm/llvm-project/issues/53950.


### PR DESCRIPTION
... to fix the following CMake 4.0 error:
```
CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
```

Related: https://github.com/kdudka/predator/pull/110